### PR TITLE
Resolve warning issue when running tests

### DIFF
--- a/packages/app/pyproject.toml
+++ b/packages/app/pyproject.toml
@@ -21,3 +21,4 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
Fixes #4

Resolve `PytestDeprecationWarning` related to `asyncio_default_fixture_loop_scope`.

* Set `asyncio_default_fixture_loop_scope` configuration option to `function` in `packages/app/pyproject.toml` under `[tool.pytest.ini_options]`
* Ensure `asyncio_mode` is set to `auto` in `packages/app/pyproject.toml` under `[tool.pytest.ini_options]`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hhimanshu/uv-workspaces/pull/6?shareId=e278ad65-f959-42a4-95c1-9cbb46ccb4be).