### PR TITLE
Resolve Pydantic deprecation warning by using ConfigDict

### DIFF
--- a/packages/app/src/models/user.py
+++ b/packages/app/src/models/user.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, EmailStr
+from pydantic import BaseModel, Field, EmailStr, ConfigDict
 
 
 class User(BaseModel):
@@ -12,11 +12,12 @@ class User(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     is_active: bool = Field(default=True)
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "email": "user@example.com",
                 "name": "John Doe",
                 "is_active": True,
             }
         }
+    )


### PR DESCRIPTION
Fixes #5

Replace the class-based `Config` with `ConfigDict` for Pydantic configuration in `packages/app/src/models/user.py`.

* Import `ConfigDict` from Pydantic.
* Remove the `Config` class.
* Add `model_config` attribute using `ConfigDict` to define the Pydantic configuration.
* Update the `json_schema_extra` configuration to be a dictionary within `ConfigDict`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hhimanshu/uv-workspaces/pull/7?shareId=654bbe68-8b08-45f9-82e2-3296e35e8266).