### PR TITLE
Fix asyncio_default_fixture_loop_scope unset issue in api workspace

### DIFF
--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -27,3 +27,5 @@ dev = [
 pythonpath = [
     "src"
 ]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
Fixes #8

Add `asyncio_default_fixture_loop_scope` configuration to `api` workspace.

* Add `[tool.pytest.ini_options]` section to `packages/api/pyproject.toml`.
* Set `asyncio_mode` to "auto" in the `[tool.pytest.ini_options]` section.
* Set `asyncio_default_fixture_loop_scope` to "function" in the `[tool.pytest.ini_options]` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hhimanshu/uv-workspaces/pull/9?shareId=f0a3da30-dc10-4ea5-8b41-8fe49d6fd196).